### PR TITLE
Move design patterns

### DIFF
--- a/_episodes/l1-01-tools-I.md
+++ b/_episodes/l1-01-tools-I.md
@@ -1,7 +1,7 @@
 ---
 title: "Tools I: Packaging and virtual-environments"
-teaching: 4
-exercises: 6
+teaching: 5
+exercises: 10
 questions:
 - How to use a package manager to install third party tools and libraries
 objectives:

--- a/_episodes/l1-02-tools-II.md
+++ b/_episodes/l1-02-tools-II.md
@@ -1,7 +1,7 @@
 ---
 title: "Tools II: Code Formatters"
-teaching: 3
-exercises: 2
+teaching: 5
+exercises: 5
 questions:
 - How to format code with no effort on the part of the coder?
 objectives:

--- a/_episodes/l1-03-tools-III.md
+++ b/_episodes/l1-03-tools-III.md
@@ -1,7 +1,7 @@
 ---
 title: "Tools III: Linters"
-teaching: 10
-exercises: 5
+teaching: 5
+exercises: 10
 questions:
 - How to make the editor pro-actively find errors and code-smells
 objectives:

--- a/_episodes/l1-04-datastructures.md
+++ b/_episodes/l1-04-datastructures.md
@@ -1,7 +1,7 @@
 ---
 title: "Data Structures"
 teaching: 30
-exercises: 20
+exercises: 25
 questions:
 - How can data structures simplify codes?
 objectives:

--- a/_episodes/l1-05-abstractions.md
+++ b/_episodes/l1-05-abstractions.md
@@ -1,7 +1,7 @@
 ---
 title: "Structuring code"
-teaching: 10
-exercises: 20
+teaching: 15
+exercises: 10
 questions:
 - How can we create simpler and more modular codes?
 objectives:

--- a/_episodes/l3-01-design_patterns.md
+++ b/_episodes/l3-01-design_patterns.md
@@ -1,7 +1,7 @@
 ---
-title: "Design Patterns"
-teaching: 15
-exercises: 15
+title: "Advanced Topic: Design Patterns"
+teaching: 30
+exercises: 30
 questions:
 - How can we avoid re-inventing the wheel when designing code?
 - How can we transfer known solutions to our code?

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,18 +1,8 @@
 ---
 title: About
 ---
-This course was developed by the Research Computing Service (RCS) of Imperial
-College, in particular by the Research Software Engineering (RSE) team. The RSE
-team are a part of Imperial ICT combining specialist knowledge in software
-engineering with extensive experience in research. The team works with academic
-groups on a wide range of projects whilst also organising community events and
-training (such as this) for the benefit of the research community. You can find
-out more at the [RSE team website][RSE] and the [Imperial RSE Community
-website][community]. You can also consult the expertise of the RSE team at the
-weekly [RCS clinic][clinic].
+<!--- about_body.md is found in the _includes dir -->
+{% include about_body.md %}
 
 {% include links.md %}
 
-[RSE]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/research-software-engineering/
-[community]: https://www.imperial.ac.uk/computational-methods/rse/
-[clinic]: http://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/support/attend-a-clinic/

--- a/_includes/about_body.md
+++ b/_includes/about_body.md
@@ -1,0 +1,14 @@
+This course was developed by the Research Computing Service (RCS) of Imperial 
+College, in particular by the Research Software Engineering (RSE) team. The RSE 
+team are a part of Imperial ICT combining specialist knowledge in software 
+engineering with extensive experience in research. The team works with academic 
+groups on a wide range of projects whilst also organising community events and 
+training (such as this) for the benefit of the research community. You can find 
+out more at the [RSE team website][RSE] and the [Imperial RSE Community 
+website][community]. You can also consult the expertise of the RSE team at the 
+weekly [RCS clinic][clinic].
+
+[RSE]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/research-software-engineering/
+[community]: https://www.imperial.ac.uk/computational-methods/rse/
+[clinic]: http://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/support/attend-a-clinic/
+

--- a/index.md
+++ b/index.md
@@ -23,4 +23,7 @@ This course covers:
 > Any introductory (graduate school) level programming course
 {: .prereq}
 
+<!--- about_body.md is found in the _includes dir -->
+{% include about_body.md %}
+
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -8,6 +8,12 @@ remotely so please make sure you have access to a suitable computer. All
 attendees should download install the applications Conda, Visual Studio Code and
 Git.
 
+> ## Important!
+>
+> Make sure that you have the most recent versions of Conda and VSCode. Some
+> features used in this lesson will not work with older versions.
+{: .callout}
+
 ## Conda
 
 Conda is a Python distribution and package manager. We use both features to


### PR DESCRIPTION
This PR addresses some of the issues laid out in #27 Please confirm that the new timings make sense for each lesson and as a whole.

Some things worth noting:
 - I have moved Design Patterns to the end of the lesson list and labelled it as "Advanced"
 - I have generally allocated a bit more time to the setup in the tooling sections to allow us more time for debugging the students' issues
 - ~It might be worth splitting the "Writing Unit Tests" episode into 2. It's currently over an hour long with two big exercises. Maybe the big problem can be an episode on it's own.~ -> implemented in #29
 - The only way I see people not correctly doing the setup is if they have old versions of the software, so I've made a note to check they have up to date versions.
 - There is now some detail about the RSE Team and the RCS on the front page