### PR TITLE
Add solution section on removing packages from conda environments

### DIFF
--- a/_episodes/l1-01-tools-I.md
+++ b/_episodes/l1-01-tools-I.md
@@ -146,8 +146,43 @@ systems.
 >    ```
 >
 >     and see whether the package has been updated or removed.
+>
+> >## Solution
+> >
+> > After completing step 7 you will find that the package has not been removed
+> > from the environment even after being removed from `environment.yml`! If we
+> > run `conda env update --help` we get:
+> > ```
+> > usage: conda-env update [-h] [-n ENVIRONMENT | -p PATH] [-f FILE] [--prune]
+> >                         [--json] [-v] [-q]
+> >                         [remote_definition]
+> > 
+> > Update the current environment based on environment file
+> > 
+> > Options:
+> > 
+> > positional arguments:
+> >   remote_definition     remote environment definition / IPython notebook
+> > 
+> > optional arguments:
+> >   -h, --help            Show this help message and exit.
+> >   -f FILE, --file FILE  environment definition (default: environment.yml)
+> >   --prune               remove installed packages not defined in environment.yml
+> > ```
+> > {: .output}
+> >
+> > Notice the `--prune` option. From the documentation it looks like we would
+> > need to run `conda env update --prune -f "path_to_environment.yml"`. There
+> > is an extra catch however, there is a long standing [bug][prune bug] in
+> > conda that means that the `--prune` option doesn't work properly. This means
+> > that the only reliable way to remove packages from your environment after
+> > they have been removed from `environment.yml` is to rebuild the environment
+> > from scratch.
+> {: .solution}
 {: .challenge}
 
+[prune bug]: https://github.com/conda/conda/issues/7279
+ 
 ## Selecting an environment in Visual Studio Code
 
 If you haven't already, see the [setup guide](../setup) for instructions on how


### PR DESCRIPTION
This PR addresses a long standing point of confusion from the Packaging and Virtual Environments lesson whereby removing the package from `environment.yml` is not reflected when `conda env update` is run.