### PR TITLE
Add a check-links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,21 @@
+name: Check links in Markdown files
+on:
+  schedule:
+    - cron: 0 0 * * 1 # midnight every Monday
+  push:
+    branches: [gh-pages]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: yes
+          use-verbose-mode: yes
+          folder-path: "_episodes, _extras, _includes"
+          file-path: "./README.md, ./LICENSE.md, ./CODE_OF_CONDUCT.md, CONTRIBUTING.md, reference.md, setup.md, index.md"
+          config-file: .mlc_config.json

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,6 @@
+{
+    "ignorePatterns": [
+        "^https://opensource.org/",
+        "^https://turing.ac.uk/"
+    ]
+}

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -4,7 +4,7 @@
 [ci]: http://communityin.org/
 [coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
 [coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
-[concept-maps]: https://carpentries.github.io/instructor-training/05-memory/
+[concept-maps]: https://carpentries.github.io/instructor-training/05-memory
 [contrib-covenant]: https://contributor-covenant.org/
 [contributing]: {{ repo_url }}/blob/{{ source_branch }}/CONTRIBUTING.md
 [cran-checkpoint]: https://cran.r-project.org/package=checkpoint
@@ -12,12 +12,10 @@
 [cran-stringr]: https://cran.r-project.org/package=stringr
 [dc-lessons]: http://www.datacarpentry.org/lessons/
 [email]: mailto:team@carpentries.org
-[github-importer]: https://import.github.com/
 [importer]: https://github.com/new/import
 [jekyll-collection]: https://jekyllrb.com/docs/collections/
 [jekyll-install]: https://jekyllrb.com/docs/installation/
 [jekyll-windows]: http://jekyll-windows.juthilo.com/
-[jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
 [kramdown]: https://kramdown.gettalong.org/
 [lc-lessons]: https://librarycarpentry.org/lessons/


### PR DESCRIPTION
This PR adds a workflow to run the markdown link check action.

Opening in draft to trigger the workflow to see which links are currently broken

Close #48 

**Edit:** This is now ready for review