### PR TITLE
Recommend ruff and mypy for QA

### DIFF
--- a/_episodes/l1-01-tools-I.md
+++ b/_episodes/l1-01-tools-I.md
@@ -87,9 +87,7 @@ systems.
 >    name: course
 >    dependencies:
 >      - python==3.11
->      - flake8
->      - pylint
->      - black
+>      - ruff
 >      - mypy
 >      - requests
 >    ```

--- a/_episodes/l1-02-tools-II.md
+++ b/_episodes/l1-02-tools-II.md
@@ -28,8 +28,12 @@ keypoints:
 1. Choose one
 1. Stick with it
 
-We chose [black](https://pypi.org/project/black/) because it has very few
-options with which to fiddle.
+We chose [ruff](https://astral.sh/ruff) because it is modern, comprehensive
+and runs very quickly. The ruff package is a collection of tools for ensuring
+code quality in Python, including a code formatter and linter. We discuss its
+formatter here, but will discuss the linter later as well.
+
+A simpler alternative formatter is [black](https://pypi.org/project/black/), which has fewer options to fiddle with.
 
 > ## Formatters in other languages
 > - **R**: [styler](https://styler.r-lib.org/), with [RStudio integration](https://styler.r-lib.org/reference/styler_addins.html).

--- a/_episodes/l1-02-tools-II.md
+++ b/_episodes/l1-02-tools-II.md
@@ -33,7 +33,7 @@ and runs very quickly. The ruff package is a collection of tools for ensuring
 code quality in Python, including a code formatter and linter. We discuss its
 formatter here, but will discuss the linter later as well.
 
-A simpler alternative formatter is [black](https://pypi.org/project/black/), which has fewer options to fiddle with.
+A simpler alternative formatter is [black](https://black.readthedocs.io/), which has fewer options to fiddle with.
 
 > ## Formatters in other languages
 > - **R**: [styler](https://styler.r-lib.org/), with [RStudio integration](https://styler.r-lib.org/reference/styler_addins.html).

--- a/_episodes/l1-02-tools-II.md
+++ b/_episodes/l1-02-tools-II.md
@@ -29,7 +29,7 @@ keypoints:
 1. Stick with it
 
 We prefer [ruff](https://astral.sh/ruff) because it is modern, comprehensive
-and runs very quickly. The ruff package is a collection of tools for ensuring
+and runs very quickly. The `ruff` package is a collection of tools for ensuring
 code quality in Python, including a code formatter and linter. We discuss its
 formatter here, but will discuss the linter later as well.
 

--- a/_episodes/l1-02-tools-II.md
+++ b/_episodes/l1-02-tools-II.md
@@ -28,7 +28,7 @@ keypoints:
 1. Choose one
 1. Stick with it
 
-We chose [ruff](https://astral.sh/ruff) because it is modern, comprehensive
+We prefer [ruff](https://astral.sh/ruff) because it is modern, comprehensive
 and runs very quickly. The ruff package is a collection of tools for ensuring
 code quality in Python, including a code formatter and linter. We discuss its
 formatter here, but will discuss the linter later as well.

--- a/_episodes/l1-03-tools-III.md
+++ b/_episodes/l1-03-tools-III.md
@@ -15,7 +15,7 @@ keypoints:
 
 ## What is linting?
 
-Linters enforce [style rules](https://lintlyci.github.io/Flake8Rules/) on your
+Linters enforce [style rules](https://docs.astral.sh/ruff/rules/) on your
 code such as:
 
 - disallow one letter variables outside of loops
@@ -51,7 +51,12 @@ Linters can also catch common errors such as:
 1. Choose one or more
 1. Stick with them
 
-We chose:
+We prefer:
+
+- [ruff](https://astral.sh/ruff) for fast and modern general linting
+- [mypy](https://mypy.readthedocs.io/) for preventing type-related code errors
+
+You may also see these linters used by some projects:
 
 - [flake8](https://pypi.org/project/black/) because it is simple
 - [pylint](https://www.pylint.org/) because it is (too?) extensive

--- a/_episodes/l1-03-tools-III.md
+++ b/_episodes/l1-03-tools-III.md
@@ -51,15 +51,15 @@ Linters can also catch common errors such as:
 1. Choose one or more
 1. Stick with them
 
-We prefer:
-
-- [ruff](https://astral.sh/ruff) for fast and modern general linting
-- [mypy](https://mypy.readthedocs.io/) for preventing type-related code errors
+We prefer [ruff](https://astral.sh/ruff) for fast and modern general linting.
+`ruff` is also a great choice for a linter because it incorporates the checks of
+multiple other linters, such as `flake8` and `pydocstyle`, into a single tool.
 
 You may also see these linters used by some projects:
 
 - [flake8](https://flake8.pycqa.org/) because it is simple
 - [pylint](https://www.pylint.org/) because it is (too?) extensive
+- [mypy](https://mypy.readthedocs.io/) for preventing type-related code errors
 
 Checkout [GitHub.com: Awesome Linters] to see the range of linters available for
 different languages.

--- a/_episodes/l1-03-tools-III.md
+++ b/_episodes/l1-03-tools-III.md
@@ -58,7 +58,7 @@ We prefer:
 
 You may also see these linters used by some projects:
 
-- [flake8](https://pypi.org/project/black/) because it is simple
+- [flake8](https://flake8.pycqa.org/) because it is simple
 - [pylint](https://www.pylint.org/) because it is (too?) extensive
 
 Checkout [GitHub.com: Awesome Linters] to see the range of linters available for


### PR DESCRIPTION
This PR changes the recommended formatter to ruff, and recommended linters to ruff and mypy, as discussed prior.

I've updated the deps in the env file, so the [messy code example](https://github.com/ImperialCollegeLondon/grad_school_sw_engineering_messy_code) will need an associated change as well. I don't seem to have write access to it though... :confused: 

Resolves #39 
