### PR TITLE
gh_variables.html: Hardcode default branch name to work around bug

### DIFF
--- a/_includes/gh_variables.html
+++ b/_includes/gh_variables.html
@@ -15,15 +15,9 @@ First, get the name of the repository
 {% assign repo_name = site.github.repository_name %}
 
 {% comment %}
-`site.github.public_repositories` contains comprehensive information for all public repositories for the organization. We use `where` to extract the part
-of the metadata that is relevant to the present repository.
+**HACK**: Hardcode the default branch name
 {% endcomment %}
-{% assign repo_info = site.github.public_repositories | where: "name", repo_name %}
-
-{% comment %}
-Now, we can extract the default branch for the repo
-{% endcomment %}
-{% assign default_branch = repo_info[0].default_branch %}
+{% assign default_branch = "gh-pages" %}
 
 {% comment %}
 Other variables requested by the template


### PR DESCRIPTION
The problem is that `gh_variables.html` contains logic to crawl the GitHub org's publicly available repos in order to find the current one and extract information, but isn't robust to errors caused by inaccessible repos (in this case due to a DMCA takedown). Fix by hardcoding the default branch name here instead.