### PR TITLE
Fix uninformative links

### DIFF
--- a/episodes/l3-01-design_patterns.md
+++ b/episodes/l3-01-design_patterns.md
@@ -58,8 +58,9 @@ software design patterns: typical solutions to common problems
     or simplify the creation of similar objects into a single function.
 - [Adapter](https://en.wikipedia.org/wiki/Adapter_pattern) pattern interfaces
   one class to be used in an another
-- [More](https://en.wikipedia.org/wiki/Software_design_pattern) and
-  [more](https://refactoring.guru/design-patterns) patterns
+- [The Wikipedia entry](https://en.wikipedia.org/wiki/Software_design_pattern) and
+  [Refactoring Guru site](https://refactoring.guru/design-patterns) detail more
+  design patterns
 - And let's not forget
   [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern#Software_engineering),
   i.e. patterns that should **not** be used

--- a/episodes/l3-01-design_patterns.md
+++ b/episodes/l3-01-design_patterns.md
@@ -59,8 +59,7 @@ software design patterns: typical solutions to common problems
 - [Adapter](https://en.wikipedia.org/wiki/Adapter_pattern) pattern interfaces
   one class to be used in an another
 - [More](https://en.wikipedia.org/wiki/Software_design_pattern) and
-  [more](https://refactoring.guru/design-patterns) and
-  [more](https://stackoverflow.com/) patterns
+  [more](https://refactoring.guru/design-patterns) patterns
 - And let's not forget
   [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern#Software_engineering),
   i.e. patterns that should **not** be used

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -71,8 +71,7 @@ however we strongly suggest that you use VS Code for this course and afterwards
 replicate the setup as you choose. *If you already have VS Code installed please
 make sure it is updated to the latest version.*
 
-To install VS Code follow the instructions
-[here](https://code.visualstudio.com).
+To install VS Code follow [these instructions](https://code.visualstudio.com).
 
 You should then be able to launch VS Code and see something like:
 ![Screenshot of VS code](fig/vs-code.png)


### PR DESCRIPTION
This PR changes the link text for some links to design patterns and VS code installation instructions.

One of the design pattern links was just to Stack Overflow homepage, which I removed.

Closes #70 