### PR TITLE
Small fixes for summary/lesson 1

### DIFF
--- a/episodes/l1-01-tools-I.md
+++ b/episodes/l1-01-tools-I.md
@@ -140,11 +140,9 @@ systems.
    requests.__file__
    ```
 
-   ```
+   ```output
    'C:\\ProgramData\\Anaconda3\\envs\\course\\lib\\site-packages\\requests\\__init__.py'
    ```
-
-   {: .output}
 
    The file path you see will vary but note that it is within a directory
    called `course` that contains all of the files for the virtual environment

--- a/episodes/l1-01-tools-I.md
+++ b/episodes/l1-01-tools-I.md
@@ -187,9 +187,9 @@ optional arguments:
 Notice the `--prune` option. From the documentation it looks like we would
 need to run `conda env update --prune -f "path_to_environment.yml"`. That
 flag is necessary to really uninstall unnecesary packages and update the
-environment. After running this command, `import resquest` will fail.
+environment. After running this command, `import requests` will fail.
 
-**Note**: If you are running `conda<23.9.0`, `import request` will still
+**Note**: If you are running `conda<23.9.0`, `import requests` will still
 work as there was a bug before that. You can check your conda version with
 `conda --version`.
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -126,29 +126,29 @@ and we will help you to fix whatever issue you were facing with your computer.
 To use Codespaces with the course examples:
 
 1. Go to the GitHub repository containing the code for the example.
-2. Click in the green `Code` button, select the `Codespaces` tab and click in
-`Create codespace on main`. A new tab will open in your brlowser, launching
+1. Click in the green `Code` button, select the `Codespaces` tab and click in
+`Create codespace on main`. A new tab will open in your browser, launching
 VSCode in there, creating a suitable virtual environment and installing the
 dependencies.
 
-![](fig/create_codespace.png){alt='Screenshot of dialog in GitHub to see existing Codespaces and to create new ones.'}
+    ![](fig/create_codespace.png){alt='Screenshot of dialog in GitHub to see existing Codespaces and to create new ones.'}
 
 1. At some point, a pop-up message will ask if you want to install the
 recommended extensions. Say 'yes' and wait until everything is installed.
 
-![](fig/install_recommended.png){alt='Screenshot of confirmation dialog in VS Code asking if recommended extensions should be installed.'}
+    ![](fig/install_recommended.png){alt='Screenshot of confirmation dialog in VS Code asking if recommended extensions should be installed.'}
 
 1. Now, you need to select the new python environment that has been installed.
 Open any python file and click in the Python version number label at the bottom,
 right corner.
 
-![](fig/choose_python.png){alt='Screenshot of VS Code with an arrow pointing to the bottom bar where the current Python environment is indicated.'}
+    ![](fig/choose_python.png){alt='Screenshot of VS Code with an arrow pointing to the bottom bar where the current Python environment is indicated.'}
 
 1. This will display at the top of the window a list of suitable Python
 environment. Select the recommended one, which should be the one that says
 `('venv')` or `('venv': conda)`.
 
-![](fig/select_venv.png){alt='Screenshot of VS Code showing the selector of available Pyton environment to choose from.'}
+    ![](fig/select_venv.png){alt='Screenshot of VS Code showing the selector of available Pyton environment to choose from.'}
 
 And that is all! You should be able to use this VSCode within the Codespace the
 same way you use it locally. You can close the tab and go back to the Codespace


### PR DESCRIPTION
Fixes a few typos, and some formatting issues:

1. Incorrect list numbering

<img width="782" height="779" alt="Screenshot 2026-05-12 092741" src="https://github.com/user-attachments/assets/e20063cc-37e4-499a-930e-f2d097e7a6e8" />

The best way to fix, whilst keeping markdownlint happy, was to indent the images so the list doesn't get broken up

2. `{:. output}` artifact

<img width="629" height="172" alt="Screenshot 2026-05-12 092819" src="https://github.com/user-attachments/assets/a4d48f17-4e06-4505-a9c8-232100d4284b" />

Possibly an artifact from the migration? I believe the intention was to mark the above code block as output, so this is what I've done
