### PR TITLE
Fix links, typos and small change to code snippet

### DIFF
--- a/episodes/l1-02-tools-II.md
+++ b/episodes/l1-02-tools-II.md
@@ -110,7 +110,7 @@ def f(a):
 ```
 
 Ah! much better! But note that the `# noqa: D102` exclusion instruction is not in
-the right line and there's a complain about `g` not having a docstring.
+the right line and there's a complaint about `g` not having a docstring.
 
 Still, the sharp-eyed user will notice at least one issue with this code.
 *Formatting code does not make it less buggy!*
@@ -126,7 +126,8 @@ Still, the sharp-eyed user will notice at least one issue with this code.
 If you are having trouble setting up your system with `conda` and `vscode`, or running
 through this exercise locally in your computer, you can run it in Codespaces.
 
-- Check the information in the [setup][setup#codespaces] instructions on how to run Codespaces.
+- Check the information in the [setup][setup-codespaces] instructions on how to
+run Codespaces.
 - Apply it to [this exercise repository in GitHub](https://github.com/ImperialCollegeLondon/grad_school_sw_engineering_messy_code).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/l1-04-datastructures.md
+++ b/episodes/l1-04-datastructures.md
@@ -364,8 +364,8 @@ discussed the best approach to managing dependencies for a project already.
 
 ### Pandas Data Frames
 
-The excellent and very powerful Panda's package is the go to resource for
-dealing with tabular data. Anything you might think of using Excel for, Panda's
+The excellent and very powerful Pandas package is the go to resource for
+dealing with tabular data. Anything you might think of using Excel for, Pandas
 can do better. It leans heavily on NumPy for efficient numerical operations
 whilst providing a high level interface for dealing with rows and columns of
 data via [pandas.DataFrame][pandas].
@@ -457,7 +457,7 @@ smallest_dist, nearest_index = balltree.query([centre], k=1)
 
 Another type of data structure that spans many different research domains are
 graphs/networks. There are many complex algorithms that can be applied to graphs
-so checkout the NetworkX library for its [data structures][networkx].
+so check out the NetworkX library for its [data structures][networkx].
 
 [networkx]: https://networkx.org/documentation/stable/tutorial.html
 
@@ -554,7 +554,7 @@ Don't reinvent the square wheel.
 
 ## Digital Oxford Dictionary, the wrong way and the right way (10 min)
 
-1. Implement an oxford dictionary with two `list`s, one for words, one for
+1. Implement an Oxford dictionary with two `list`s, one for words, one for
 definitions:
 
    ```yaml
@@ -758,7 +758,7 @@ first_example = {
 @dataclass(frozen=True)
 class Word:
     word: Text
-    category: Text
+    category: Category
 
 
 second_example = {

--- a/episodes/l1-05-abstractions.md
+++ b/episodes/l1-05-abstractions.md
@@ -284,7 +284,7 @@ validate. The code becomes cleaner, easier to read and to re-use.
 ### Code legibility
 
 Code is often meant to be read by an audience who has either not so much familiarity
-with it or has not work on it for a while. This audience is normally future-**you**
+with it or has not worked on it for a while. This audience is normally future-**you**
 reading past-**you**'s code.
 
 For example, given a point with coordinates `point[0]`, `point[1]`, `point[2]`,

--- a/episodes/l2-01-testing_overview.md
+++ b/episodes/l2-01-testing_overview.md
@@ -8,7 +8,7 @@ exercises: 5
 
 - Why test my software?
 - How can I test my software?
-- How much testing is 'enough'?"
+- How much testing is 'enough'?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/l2-02-testing_writing_unit_tests.md
+++ b/episodes/l2-02-testing_writing_unit_tests.md
@@ -313,7 +313,8 @@ conda env create --file "path_to_environment.yml"
 If you are having trouble setting up your system with `conda` and `vscode`, or running
 through this exercise locally in your computer, you can run it in Codespaces.
 
-- Check the information in the [setup][setup#codespaces] instructions on how to run Codespaces.
+- Check the information in the [setup][setup-codespaces] instructions on how to
+run Codespaces.
 - Apply it to [this exercise repository in GitHub](https://github.com/ImperialCollegeLondon/grad_school_sw_engineering_diffusion).
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
@@ -349,7 +350,7 @@ to Fibonacci calculation
 [jupyter-ci]: https://github.com/mwoodbri/jupyter-ci
 
 - [Hypothesis](https://hypothesis.readthedocs.io/en/latest/) provides
-  property-based testing, which is useful for verifying edge cases):
+  property-based testing, which is useful for verifying edge cases:
 
 ```python
 from fibonacci import recursive_fibonacci

--- a/links.md
+++ b/links.md
@@ -29,6 +29,7 @@ any links that you are not going to use.
 [python-gapminder]: https://swcarpentry.github.io/python-novice-gapminder/
 [pyyaml]: https://pypi.python.org/pypi/PyYAML
 [setup]: ../learners/setup.md
+[setup-codespaces]: ../learners/setup.md#codespaces
 [swc-lessons]: https://software-carpentry.org/lessons/
 [swc-releases]: https://github.com/swcarpentry/swc-releases
 [training]: https://carpentries.github.io/instructor-training/


### PR DESCRIPTION
Fixes some small typos, plus:

1. There was a broken link to the codespaces instructions in two places
<img width="643" height="51" alt="Screenshot 2026-05-12 113449" src="https://github.com/user-attachments/assets/bce48d14-3e92-4237-8785-38a286d55004" />

Since we're linking to this in multiple places, I've created a global link with the alias `setup-codespaces` in `links.md`

2. I believe the type annotation in one of the code snippets is slightly wrong 
<img width="649" height="626" alt="Screenshot 2026-05-12 114345" src="https://github.com/user-attachments/assets/d11f205d-e671-4c4e-9dba-90c9e65ce67e" />

We're currently annotating `category` as `Text`, but w'ere actually using the above-defined `Category` enum for this field. Not hugely important but better to be correct