### PR TITLE
Replace 'poetry' with `uv` in the list of package managers

### DIFF
--- a/episodes/l1-01-tools-I.md
+++ b/episodes/l1-01-tools-I.md
@@ -38,17 +38,17 @@ exercises: 10
 Package managers help you install packages. Some help you install virtual environments
 as well. Better known python package managers include
 [conda](https://docs.conda.io/en/latest/), [pip](https://pip.pypa.io/en/stable/),
-[poetry](https://python-poetry.org/)
+[uv](https://docs.astral.sh/uv/)
 
-|                           | conda    | pip | poetry     |
+|                           | conda    | pip | uv     |
 |---------------------------|----------|-----|------------|
 |audience                   | research | all | developers |
 |manage python packages     | ✅       | ✅  | ✅         |
 |manage non-python packages | ✅       | ❌  | ❌         |
-|choose python version      | ✅       | ❌  | ❌         |
+|choose python version      | ✅       | ❌  | ✅         |
 |manage virtual envs        | ✅       | ❌  | ✅         |
-|easy interface             | ❌       | ✅  | ❌         |
-|fast                       | ❌       | ✅  | ✅         |
+|easy interface             | ❌       | ✅  | ✅         |
+|fast                       | ❌       | ✅  | ✅✅✅      |
 
 ::::::::::::::::::::::::::::::::::::: callout
 


### PR DESCRIPTION
Fixes #109

Replace 'poetry' with `uv`.

Note: 
I am new to using uv, and some of the values are subjective, so please check they make sense! :)